### PR TITLE
[PATCH] fix: issue in 'hide' function which is supposed to close all prompt of the selected form but it does not work. see details above.

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -154,8 +154,8 @@
          * Closes form error prompts
          */
         hide: function() {
-            var form = this;
-            form.find('.formError').fadeTo("fast", 0.3, function() {
+            var formParentalClassName = "parentForm"+$(this).attr('id');
+            $('.'+formParentalClassName).fadeTo("fast", 0.3, function() {
                 $(this).remove();
             });
         },
@@ -862,6 +862,8 @@
             // create the prompt
             var prompt = $('<div>');
             prompt.addClass(field.attr("id").replace(":","_") + "formError");
+            // add a class name to identify the parent form of the prompt
+            prompt.addClass("parentForm"+field.parents('form').attr("id").replace(":","_"));
             prompt.addClass("formError");
 
             switch (type) {


### PR DESCRIPTION
## Issue

Initial implementation of hide function try to remove all '.formError' child classes of the selected form.
In fact, 'formError' prompts are not part of the form childs but these prompt are located at top of the DOM tree.
## Solution

I added a class to make prompts identified to their form parents.
Then I updated the hide function to remove correctly all prompts which corresponds to the right form.
## 

Best regards,
Thomas PIERSON
