### PR TITLE
Added the actual number of checkboxes that must be checked to the maxCheckbox error message

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -735,6 +735,7 @@
             var groupSize = $("input[name='" + groupname + "']:checked").size();
             if (groupSize > nbCheck) {
                 options.showArrow = false;
+                if (options.allrules.maxCheckbox.alertText2) return options.allrules.maxCheckbox.alertText + " " + nbCheck + " " + options.allrules.maxCheckbox.alertText2;
                 return options.allrules.maxCheckbox.alertText;
             }
         },

--- a/js/languages/jquery.validationEngine-en.js
+++ b/js/languages/jquery.validationEngine-en.js
@@ -38,7 +38,8 @@
                 },	
                 "maxCheckbox": {
                     "regex": "none",
-                    "alertText": "* Checks allowed Exceeded"
+                    "alertText": "* Maximum ",
+                    "alertText2": " options allowed"
                 },
                 "minCheckbox": {
                     "regex": "none",

--- a/js/languages/jquery.validationEngine-tr.js
+++ b/js/languages/jquery.validationEngine-tr.js
@@ -41,7 +41,8 @@
                 },	
                 "maxCheckbox": {
                     "regex": "none",
-                    "alertText": "* Lütfen daha az onay kutusu işareyleyiniz"
+                    "alertText": "* En fazla ",
+                    "alertText2": " onay kutusu işaretleyebilirsiniz"
                 },
                 "minCheckbox": {
                     "regex": "none",


### PR DESCRIPTION
I think this makes the error message a bit more consistent with the minChechbox error message which tells you the number of checkboxes that must be checked.

I also think it's a bit more useful this way.

I went ahead and added the alertText2's to turkish and english localization files too.

I tested a few localization files that were created before this change and they work fine.

(Which they should  because the new behaviour checks for the existence of options.allrules.maxCheckbox.alertText2 and falls back to the old functionality if it doesn't exist :) )
