### PR TITLE
Improving the scroll (including overflown div's)

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -262,17 +262,21 @@
 
                     // look for the visually top prompt
                     var destination = Number.MAX_VALUE;
-
+                    var fixleft = 0;
                     var lst = $(".formError:not('.greenPopup')");
+
                     for (var i = 0; i < lst.length; i++) {
                         var d = $(lst[i]).offset().top;
-                        if (d < destination)
+                        if (d < destination){
                             destination = d;
+                            fixleft = $(lst[i]).offset().left;
+                        }
                     }
 
                     if (!options.isOverflown)
                         $("html:not(:animated),body:not(:animated)").animate({
-                            scrollTop: destination
+                            scrollTop: destination,
+                            scrollLeft: fixleft
                         }, 1100);
                     else {
                         var overflowDIV = $(options.overflownDIV);
@@ -284,6 +288,11 @@
 
                         scrollContainer.animate({
                             scrollTop: destination
+                        }, 1100);
+
+                        $("html:not(:animated),body:not(:animated)").animate({
+                            scrollTop: overflowDIV.offset().top,
+                            scrollLeft: fixleft
                         }, 1100);
                     }
                 }


### PR DESCRIPTION
This is the pull request for the issue #76:

<pre>
(...) i see some cosmetic issues related to promp position and the scrolling:
1) scroll top: i've found fails in the overflown div's when the window isn't maximized. Sometimes the promt showed isn't the first : though the scroll for an overflown div works ok, the first prompt would be hidden because the lack of compensation with the window's scroll.
2) scroll left: as the top case, with the difference that is the same for overflown or not div's. Sometimes, the window's scroll, hidde partial o totally the prompt.
(...)
Then, this changes will keeps visible the prompt don't matter its position or the size of the windows.
I've tested it on FF4 and IE8.
</pre>


Alejandro
