### PR TITLE
Minimum Size alert wording change

### DIFF
--- a/js/languages/jquery.validationEngine-en.js
+++ b/js/languages/jquery.validationEngine-en.js
@@ -13,7 +13,7 @@
                 "minSize": {
                     "regex": "none",
                     "alertText": "* Minimum ",
-                    "alertText2": " characters allowed"
+                    "alertText2": " characters required"
                 },
                 "maxSize": {
                     "regex": "none",


### PR DESCRIPTION
I think the word "required" makes more sense in the minimum size message than the word "allowed".
