### PR TITLE
Fix greenPopup turn red on resizing

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1230,21 +1230,22 @@
         _updatePrompt: function(field, prompt, promptText, type, ajaxed, options, noAnimation) {
 			
             if (prompt) {
-                if (type == "pass")
-                    prompt.addClass("greenPopup");
-                else
-                    prompt.removeClass("greenPopup");
+		if (typeof type !== "undefined") {
+	                if (type == "pass")
+        	            prompt.addClass("greenPopup");
+                	else
+			    prompt.removeClass("greenPopup");
 
-                if (type == "load")
-                    prompt.addClass("blackPopup");
-                else
-                    prompt.removeClass("blackPopup");
-
-                if (ajaxed)
-                    prompt.addClass("ajaxed");
-                else
-                    prompt.removeClass("ajaxed");
-
+			if (type == "load")
+			    prompt.addClass("blackPopup");
+			else
+			    prompt.removeClass("blackPopup");
+		}
+		if (ajaxed)
+		    prompt.addClass("ajaxed");
+		else
+		    prompt.removeClass("ajaxed");
+		
                 prompt.find(".formErrorContent").html(promptText);
 
                 var pos = methods._calculatePosition(field, prompt, options),


### PR DESCRIPTION
The bug is caused after DOM changes, where the passed "type" is `undefined`. Since it is `undefined`, the `greenPopup` and `blackPopup` classes are removed. Adding a check to see if this is undefined can fix this issue.

Changing the end of `updatePromptsPosition` like the following can also fix the issue, but I think it is less elegant.

`var type;
 if(prompt.hasClass("greenPopup")) type = 'pass';
 if(prompt.hasClass("blackPopup")) type = 'load';
 if(prompt) methods._updatePrompt(field, $(prompt), promptText, type, false, options, noAnimation);`
