### PR TITLE
New Functionality: option 'showFirstAlertForFieldOnly'

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -564,6 +564,7 @@
                 if (errorMsg !== undefined) {
                     promptText += errorMsg + "<br/>";
                     options.isError = true;
+					if (options.showFirstAlertForFieldOnly) break; 
                 }
             }
             // If the rules required is not added, an empty field is not validated
@@ -1452,6 +1453,8 @@
         ajaxValidCache: {},
         // Auto update prompt position after window resize
 		autoPositionUpdate: false,
+		// Option to only show the first alert text when using multiple validators.
+		showFirstAlertForFieldOnly:false,
 
         InvalidFields: [],
 		onSuccess: false,


### PR DESCRIPTION
New Functionality: When using multiple validators on field, only the first validation alert is shown.
When using multiple validators all failed validations are shown in the popup. This enhancement adds a new option 'showFirstAlertForFieldOnly' which, when set to true, which only show the first validate error for a field in the popup. By default (false) the validation behaves as before.

This also also satisfies a question posted on the support forum (only the first part)
http://validationengine.vanillaforums.com/discussion/88/two-questions-1-how-can-i-make-a-field-only-show-one-error-2-onsuccess-callback-not-working
