### PR TITLE
Fix for Elements with dot in Id

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1292,7 +1292,7 @@
          * @return undefined or the error prompt (jqObject)
          */
   		  _getPrompt: function(field) {
-		    var className = field.attr("id").replace(":","_") + "formError";
+		    var className = methods._getClassName(field.attr("id")) + "formError";
 		    var match = $("." + methods._escapeExpression(className))[0];
 		    if (match)
 		      return $(match);


### PR DESCRIPTION
Element Ids with dot are now replaced with underscore in _getPrompt() function, so there is no Error when validating the Form.
