### PR TITLE
Add a way to use POST instead GET for AJAX form validation

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -380,9 +380,10 @@
         _validateFormWithAjax: function(form, options) {
 
             var data = form.serialize();
-			var url = (options.ajaxFormValidationURL) ? options.ajaxFormValidationURL : form.attr("action");
+            var url = (options.ajaxFormValidationURL) ? options.ajaxFormValidationURL : form.attr("action");
+            var type = (form.attr("method") == "post") ? "POST" : "GET";
             $.ajax({
-                type: "GET",
+                type: type,
                 url: url,
                 cache: false,
                 dataType: "json",


### PR DESCRIPTION
It will read the method param of the form to check if it's post or get, and do the ajax call with that type.
