### PR TITLE
improved 'relative' mode positioning

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -313,7 +313,7 @@
             form.find('[class*=validate]').not(':hidden').not(":disabled").each( function() {
                 var field = $(this);
                 errorFound |= methods._validateField(field, options, skipAjaxValidation);
-				field.focus();
+			field.focus();
                 if (options.doNotShowAllErrosOnSubmit)
                     return false;
 		    if (errorFound && first_err==null) first_err=field; 
@@ -1250,11 +1250,14 @@
             }
 
     	    if (options.relative) {
-        		// empty relative span does not disturb page layout
+        		// empty relative span does not disturb page layout if relativePadding = False
         		// prompt positioned absolute to relative span
         		// vertical-align:top so position calculations are the same as isOverflown
-        		var outer = $('<span>').css('position','relative').css('vertical-align','top').addClass('formErrorOuter').append(prompt.css('position','absolute'));
-        		field.before(outer);
+        		var outer = $('<div>').css('position','relative').css('vertical-align','top').addClass('formErrorOuter').append(prompt.css('position','absolute'));
+        		field.after(outer);
+        		if(options.relativePadding) {
+        		  outer.css('padding-bottom', prompt.height() + 'px');
+        		}
     	    } else if (options.isOverflown) {
                 //Cedric: Needed if a container is in position:relative
                 // insert prompt in the form or in the overflown container?
@@ -1642,6 +1645,8 @@
 
 	    // better relative positioning
 	    relative: false,
+	    // insert spacing when error prompts inserted if relative = True and relativePadding = True
+	    relativePadding: true,
         // Used when the form is displayed within a scrolling DIV
         isOverflown: false,
         overflownDIV: "",


### PR DESCRIPTION
I liked the idea of turning on the 'relative' option, but in my layout at least (a simple jQuery Mobile form) it was pretty broken. I made some changes to improve how the error prompts are positioned. This includes:
- changing the container span to a div so that it uses block positioning and shows up under the field
- inserting the div AFTER the field to improve the layout, not before
- added a relativePadding option that will insert spacing under the prompt that's the height of the prompt window itself, this does disturb the form, but allows it so that the error prompts do not flow over the fields/field labels below them. This option may be turned off to not disturb the form.
- Seems to work fine with promptPosition settings

The results are MUCH better at least for me, see from the images below... (ignore the error prompt text shadow, that was a css bug unrelated to validationengine that I fixed)

firefox 8 on windows 7:
original: http://dl.dropbox.com/u/9719672/validationengineimg/firefox8_orig.png
new: http://dl.dropbox.com/u/9719672/validationengineimg/firefox8_new.png

ios 5.0.1 on iPhone 4:
original: http://dl.dropbox.com/u/9719672/validationengineimg/ios5_orig.png
new: http://dl.dropbox.com/u/9719672/validationengineimg/ios5_new.png
