### PR TITLE
Validate ajax fields if there is no whole form validation.

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -250,8 +250,9 @@
 			var form = $(this);
 			var options = form.data('jqv');
 
-			// validate each field (- skip field ajax validation, no necessary since we will perform an ajax form validation)
-			var r=methods._validateFields(form, true);
+			// validate each field 
+			// (- skip field ajax validation, not necessary IF we will perform an ajax form validation)
+			var r=methods._validateFields(form, options.ajaxFormValidation);
 
 			if (r && options.ajaxFormValidation) {
 				methods._validateFormWithAjax(form, options);


### PR DESCRIPTION
If you have a form with ajax field validations but no ajax form validation, it will not check the ajax fields before allowing the form to submit.

This patch allows for ajax field checking in the case when there is no form validation.  This is very useful in the case that the form only has one ajaxfield validation (the server only needs to support the field validation and not a whole form validation).
