### PR TITLE
Updated hide to find the correct form

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -193,8 +193,9 @@
 		/**
 		* Closes form error prompts, CAN be invidual
 		*/
-		 hide: function() {
-			 var form = this;
+		hide: function() {
+			 var form = $(this).closest('form');
+			 if(form.length == 0) return this;
 			 var options = form.data('jqv');
 			 var closingtag;
 			 if($(this).is("form")){


### PR DESCRIPTION
As promised, hide now uses `closest` rather than assuming `this` is the correct form.

Also worth updating all the other functions that use `var form = this;` to use `var form = $(this).closest('form');` as based on my tests, `this` is a form, it will return the correct form and if `this` is a field within a form, it will return the associated form.

HTH

Gav
