### PR TITLE
Name attribute for text fields no longer needs to be unique

### DIFF
--- a/demos/demoDoubleNames.html
+++ b/demos/demoDoubleNames.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+	<title>JQuery Validation Engine</title>
+	<link rel="stylesheet" href="../css/validationEngine.jquery.css" type="text/css"/>
+	<link rel="stylesheet" href="../css/template.css" type="text/css"/>
+	<script src="../js/jquery-1.6.min.js" type="text/javascript">
+	</script>
+	<script src="../js/languages/jquery.validationEngine-en.js" type="text/javascript" charset="utf-8">
+	</script>
+	<script src="../js/jquery.validationEngine.js" type="text/javascript" charset="utf-8">
+	</script>
+	<script>
+		jQuery(document).ready(function(){
+			// binds form submission and fields to the validation engine
+			jQuery("#formID").validationEngine();
+		});
+	</script>
+</head>
+<body>
+	<p>
+		<a href="../index.html" >Back to index</a>
+	</p>
+	<p>
+		This demonstration shows that the plugin can validate form elements without having to worry about double name fields.
+	</p>
+	<form id="formID" class="formular" method="post">
+		<fieldset>
+			<legend>
+				Double names
+			</legend>
+			<label>
+				<span>This field has the name "double"<br/>and is required : </span>
+				<input value="" class="validate[required] text-input" type="text" name="double" />
+			</label>
+			<label>
+				<span>This field also has the name "double"<br/>and is also required : </span>
+				<input value="" class="validate[required] text-input" type="text" name="double" />
+			</label>
+		</fieldset>
+		<input class="submit" type="submit" value="Validate &amp; Send the form!"/><hr/>
+	</form>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@
 		<li>
 			<a href="demos/demoPositioning.html">Demo Positioning</a>
 		</li>
+		<li>
+			<a href="demos/demoDoubleNames.html">Demo Double Names</a>
+		</li>
 	</ul>
 	<h2>Documentation</h2>
 	<a href="https://github.com/posabsolute/jQuery-Validation-Engine">Github</a>

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -593,11 +593,6 @@
 				options.showArrow = false;
 			}
 
-			if (fieldType == "text" && form.find("input[name='" + fieldName + "']").size() > 1) {
-				field = $(form.find("input[name='" + fieldName + "'][type!=hidden]:first"));
-				options.showArrow = false;
-			}
-
 			if (options.isError){
 				methods._showPrompt(field, promptText, "", false, options);
 			}else{


### PR DESCRIPTION
When I was testing fields in combination with visibility scope (showing only used fields which were name unique) I experienced a bug where the validationEngine wouldn't validate fields which were visible but had name siblings which were hidden.

I've added a new demo page to show what I mean. You can re-enable the part I removed from the validationEngine script to see the problem at hand.

Basically: you can now use text fields with the same name and the validator will just validate those specific fields without worrying about double names.
