### PR TITLE
Use 'past' and 'future' date validation between multiple DatePicker fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,21 +418,22 @@ Validates if the element content size (in characters) is less than, or equal to,
 
 ### past[NOW, a date or another element's name]
 
-Checks if the element's value (which is implicitly a date) is earlier than the given *date*. When "NOW" is used as a parameter, the date will be calculate in the browser. When a "field name" is used, it will compare the element's value with another element's value within the same form. Note that this may be different from the server date. Dates use the ISO format YYYY-MM-DD
+Checks if the element's value (which is implicitly a date) is earlier than the given *date*. When "NOW" is used as a parameter, the date will be calculate in the browser. When a "#field name" is used ( The '#' is optional ), it will compare the element's value with another element's value within the same form. Note that this may be different from the server date. Dates use the ISO format YYYY-MM-DD
 
 ```html
 <input value="" class="validate[required,custom[date],past[now]]" type="text" id="birthdate" name="birthdate" />
 <input value="" class="validate[required,custom[date],past[2010-01-01]]" type="text" id="appointment" name="appointment" />
-<input value="" class="validate[required,custom[date],past[appointment]]" type="text" id="restaurant" name="restaurant" />
+<input value="" class="validate[required,custom[date],past[#appointment]]" type="text" id="restaurant" name="restaurant" />
+<input value="" class="validate[required,custom[date],past[appointment]]" type="text" id="restaurant_2" name="restaurant_2" />
 ```
 
 ### future[NOW, a date or another element's name]
 
-Checks if the element's value (which is implicitly a date) is greater than the given *date*. When "NOW" is used as a parameter, the date will be calculate in the browser. When a "field name" is used, it will compare the element's value with another element's value within the same form. Note that this may be different from the server date. Dates use the ISO format YYYY-MM-DD
+Checks if the element's value (which is implicitly a date) is greater than the given *date*. When "NOW" is used as a parameter, the date will be calculate in the browser. When a "#field name" is used ( The '#' is optional ), it will compare the element's value with another element's value within the same form. Note that this may be different from the server date. Dates use the ISO format YYYY-MM-DD
 
 ```html
 <input value="" class="validate[required,custom[date],future[now]]" type="text" id="appointment" name="appointment" />
-<input value="" class="validate[required,custom[date],future[appointment]]" type="text" id="restaurant" name="restaurant" />
+<input value="" class="validate[required,custom[date],future[#appointment]]" type="text" id="restaurant" name="restaurant" />
 // a date in 2009
 <input value="" class="validate[required,custom[date],future[2009-01-01],past[2009-12-31]]" type="text" id="d1" name="d1" />
 ```

--- a/demos/demoValidators.html
+++ b/demos/demoValidators.html
@@ -298,16 +298,16 @@
 					<input class="checkbox" type="checkbox" name="name1" id="name1" onclick="javascript:ToggleState('#name1', '#dateCmp1');" />
 					<i>Disable first date field</i><br />
 				</label>
-				<input value="2011/3/4" class="validate[custom[date],past[dateCmp2]]" type="text" name="dateCmp1" id="dateCmp1" />
+				<input value="2011/3/4" class="validate[custom[date],past[#dateCmp2]]" type="text" name="dateCmp1" id="dateCmp1" />
 				<br/>
-				validate[custom[date],past[dateCmp2]]<br /><br />
+				validate[custom[date],past[#dateCmp2]]<br /><br />
 				<label>Second Date :<br />
 					<input class="checkbox" type="checkbox" name="name2" id="name2" onclick="javascript:ToggleState('#name2', '#dateCmp2');" />
 					<i>Disable second date field</i><br />
 				</label>
-				<input value="2010/1/2" class="validate[custom[date],future[dateCmp1]]" type="text" name="dateCmp2" id="dateCmp2" />
+				<input value="2010/1/2" class="validate[custom[date],future[#dateCmp1]]" type="text" name="dateCmp2" id="dateCmp2" />
 				<br/>
-				validate[custom[date],future[dateCmp1]]<br />
+				validate[custom[date],future[#dateCmp1]]<br />
 		</fieldset>
 
 		<fieldset>

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -834,7 +834,7 @@
 		_past: function(form, field, rules, i, options) {
 
 			var p=rules[i + 1];
-			var fieldAlt = $(form.find("input[name='" + p + "']"));
+			var fieldAlt = $(form.find("input[name='" + p.replace(/^#+/, '') + "']"));
 			var pdate;
 
 			if (p.toLowerCase() == "now") {
@@ -867,7 +867,7 @@
 		_future: function(form, field, rules, i, options) {
 
 			var p=rules[i + 1];
-			var fieldAlt = $(form.find("input[name='" + p + "']"));
+			var fieldAlt = $(form.find("input[name='" + p.replace(/^#+/, '') + "']"));
 			var pdate;
 
 			if (p.toLowerCase() == "now") {


### PR DESCRIPTION
Adding suggested enhancement #358, Use 'past' and 'future' date validation between multiple DatePicker fields.

First time I do this branching stuff and pull request. Hope I'm doing it well.

Julien.
