### PR TITLE
Fixes: promptPosition centerRight does not work when jQueryUI is also loaded

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1479,7 +1479,7 @@
 				case "centerRight":
 					promptTopPosition = fieldTop+4;
 					marginTopSize = 0;
-					promptleftPosition= fieldLeft + field.outerWidth(1)+5;
+					promptleftPosition= fieldLeft + field.outerWidth(true)+5;
 					break;
 				case "centerLeft":
 					promptleftPosition = fieldLeft - (promptElmt.width() + 2);


### PR DESCRIPTION
This commit changes a call to `outerWidth(1)` to `outerWidth(true)`. While seemingly innocuous, this updates it to match the jQuery documentation, allows it to work with jQueryUI, and future proofs it for jQuery edge versions which use `outerWidth()` as a getter AND setter.

Explanation:

There is a call in `_calculatePosition` which uses `outerWidth(1)` to determine the width of the input when placing the prompt next to it. The desire of the call is to get an integer containing the full elements padding, margin, and borders. BUT, when jQueryUI is present, `outerWidth(1)` returns a reference to a jQuery object and not an integer. (Why does jQueryUI do that? I do not know). In addition, if you look at the edge version of jQuery you'll notice that `outerWidth()` will become a getter and a setter similar to how `width()` is. Thus, `outerWidth(1)` will make the element have a total width of 1px.

This commit should fix all of the above problems.

Example: http://jsfiddle.net/Ln86Q/2/

In the HTML section you'll notice there is a reference to the core library and my fork. If you validate the field using core, the prompt appears in the middle of the field. If you use my library the prompt appears where it should.
