### PR TITLE
Fixes: extraData parameter for AJAX does not behave as expected.

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1062,9 +1062,22 @@
 			 var rule = options.allrules[errorSelector];
 			 var extraData = rule.extraData;
 			 var extraDataDynamic = rule.extraDataDynamic;
+			 var data = {
+				"fieldId" : field.attr("id"),
+				"fieldValue" : field.val()
+			 };
 
-			 if (!extraData)
-				extraData = "";
+			 if (typeof extraData === "object") {
+				$.extend(data, extraData);
+			 } else if (typeof extraData === "string") {
+				var tempData = extraData.split("&");
+				for(var i = 0; i < tempData.length; i++) {
+					var values = tempData[i].split("=");
+					if (values[0] && values[0]) {
+						data[values[0]] = values[1];
+					}
+				}
+			 }
 
 			 if (extraDataDynamic) {
 				 var tmpData = [];
@@ -1074,12 +1087,9 @@
 					 if ($(id).length) {
 						 var inputValue = field.closest("form").find(id).val();
 						 var keyValue = id.replace('#', '') + '=' + escape(inputValue);
-						 tmpData.push(keyValue);
+						 data[id.replace('#', '')] = inputValue;
 					 }
 				 }
-				 extraDataDynamic = tmpData.join("&");
-			 } else {
-				 extraDataDynamic = "";
 			 }
 
 			 if (!options.isError) {
@@ -1088,7 +1098,7 @@
 					 url: rule.url,
 					 cache: false,
 					 dataType: "json",
-					 data: "fieldId=" + field.attr("id") + "&fieldValue=" + field.val() + "&extraData=" + extraData + "&" + extraDataDynamic,
+					 data: data,
 					 field: field,
 					 rule: rule,
 					 methods: methods,


### PR DESCRIPTION
This fix does 3 things. 

1) The `extraData` parameter can now be passed as "name=value&name2=value2" (query string syntax) or as an object { name : value, name2 : value2 }.
2) Fixes a bug where the extraData parameter didn't actually work according to the documentation. In the docs the example is "name=eric", but that results in a query string of "extraData=name=eric" which I don't think is the desired result.
3) All parameters - extraData, extraDataDynamic, fieldId, fieldValue - are put into the same object `data` and passed to the `$.ajax` call as `$.ajax({ data : data })` rather than concatenating the different values together in a complex string. This simplifies the process, lets jQuery handle the serialization and reduces error pathways.
