### PR TITLE
Do not validate empty fields that is not required.

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -581,7 +581,7 @@
 				}
 			}
 			// If the rules required is not added, an empty field is not validated
-			if(!required && field.val() == "" && !promptText) options.isError = false;
+			if(!required && field.val().length < 1) options.isError = false;
 
 			// Hack for radio/checkbox group button, the validation go into the
 			// first radio/checkbox of the group

--- a/tests/issue430.html
+++ b/tests/issue430.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Issue #430: Do not validate empty fields that is not required.</title>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" type="text/css" href="../css/validationEngine.jquery.css" />
+    <script type="text/javascript" src="../js/jquery-1.7.2.min.js"></script>
+    <script type="text/javascript" src="../js/languages/jquery.validationEngine-en.js"></script>
+    <script type="text/javascript" src="../js/jquery.validationEngine.js"></script>
+    <script type="text/javascript">
+      $(document).ready(function() {
+        // Define a custom validation function.
+        $.validationEngineLanguage.allRules['test_value'] = {
+          "func": function(field, rules, i, options) {
+            return (field.val() == 'test');
+          },
+          "alertText": "* Value must be 'test'."
+        };
+
+        // Initiate the validation engine.
+        $('#form').validationEngine();
+      });
+    </script>
+  </head>
+  <body>
+    <h1>Issue #430: Do not validate empty fields that is not required.</h1>
+    <p>
+      See <a href="https://github.com/posabsolute/jQuery-Validation-Engine/issues/430">https://github.com/posabsolute/jQuery-Validation-Engine/issues/430</a>
+      for information.
+    </p>
+    <form id="form" action="/" method="POST">
+      <p>
+        <label for="test_case_1">Not required, but validate input if value is present.</label><br />
+        <input type="text" name="test_case_1" class="validate[custom[test_value]]" /><br />
+      </p>
+      <p>
+        <label for="test_case_2">Required, validate input.</label><br />
+        <input type="text" name="test_case_2" class="validate[required, custom[test_value]]" />
+      </p>
+      <input type="submit" value="Submit" />
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
This should fix issue #430. Validations should only be evaluated for fields which either has the validation rule `required` or have a value greater than zero.

A test have been made in `tests/issue430.html`.

I also noticed issue #422. If a field isn't required, the value could be of string length zero. In my opinion there is not need to run validations on optional fields with no value. If the field is either required or have a value, validations should be run.
