### PR TITLE
Load custom error message from attribute 'data-errormessage'

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,37 +99,37 @@ Customize error messages with data-errormessage and data-errormessage-* attribut
 The following attribute's value will be loaded for the relative validation rule: 
 
 ##### data-errormessage-value-missing
-required
-groupRequired
-condRequired
+* required
+* groupRequired
+* condRequired
 
 ##### data-errormessage-type-mismatch
-past
-future
-dateRange
-dateTimeRange
+* past
+* future
+* dateRange
+* dateTimeRange
 
 ##### data-errormessage-pattern-mismatch
-creditCard
-equals
+* creditCard
+* equals
 
 ##### data-errormessage-range-underflow
-minSize
-min
-minCheckbox
+* minSize
+* min
+* minCheckbox
 
 ##### data-errormessage-range-overflow
-maxSize
-max
-maxCheckbox
+* maxSize
+* max
+* maxCheckbox
 
 ##### data-errormessage-custom-error
-custom
-ajax
-funcCall
+* custom
+* ajax
+* funcCall
 
 ##### data-errormessage 
-a generic fall-back error message
+* a generic fall-back error message
 
 ### Per Field Prompt Direction
 


### PR DESCRIPTION
Load custom error message from the following standard HTML5 attributes:
data-errormessage
data-errormessage-value-missing
data-errormessage-type-mismatch
data-errormessage-pattern-mismatch
data-errormessage-too-long
data-errormessage-range-underflow
data-errormessage-range-overflow
data-errormessage-step-mismatch
data-errormessage-custom-error

Reference: http://dev.w3.org/html5/spec/constraints.html#validitystate
