### PR TITLE
Update js/jquery.validationEngine.js

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -398,7 +398,7 @@
 					methods._ajaxError(data, transport);
 				},
 				success: function(json) {
-					if (json !== true) {
+					if ((options.dataType == "json") && (json !== true)) {
 						// getting to this case doesn't necessary means that the form is invalid
 						// the server may return green or closing prompt actions
 						// this flag helps figuring it out


### PR DESCRIPTION
Updated the _validateFormWithAjax success: method to check if the dataType is indeed an JSON request or not. This will help if the dataType is NOT JSON, then it should not try to do the JSON checking.
