### PR TITLE
Update js/jquery.validationEngine.js

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -398,7 +398,7 @@
 					methods._ajaxError(data, transport);
 				},
 				success: function(json) {
-					if ((options.dataType == "json") && (json !== true)) {
+					if ((dataType == "json") && (json !== true)) {
 						// getting to this case doesn't necessary means that the form is invalid
 						// the server may return green or closing prompt actions
 						// this flag helps figuring it out
@@ -443,7 +443,8 @@
 						}
 						options.onAjaxFormComplete(!errorInForm, form, json, options);
 					} else
-						options.onAjaxFormComplete(true, form, "", options);
+						options.onAjaxFormComplete(true, form, json, options);
+
 				}
 			});
 


### PR DESCRIPTION
Minor change to the update that I had submitted previously. The check was checking options.dataType, where it should be checking that functions' set var dataType. Found it to be a bug that options.dataType was undefined if the user didn't set the dataType, but the function's set var dataType does work for the checking. Validated this in FireFox, Chrome, Safari, and IE.

Also did a minor change that if the dataType is not JSON, go ahead and pass through the data (json variable) on line 446, in case if the user's script does send something back and they are wanting to do their own processing of the sent data.
