### PR TITLE
Fix for Select2 & Similiar for real time Updating of Prompt Position

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -161,6 +161,8 @@
 			// No option, take default one
 			form.find('['+options.validateAttribute+'*=validate]').not(":disabled").each(function(){
 				var field = $(this);
+				if (options.prettySelect && field.is(":hidden"))
+				  field = form.find("#" + options.usePrefix + field.attr('id') + options.useSuffix);
 				var prompt = methods._getPrompt(field);
 				var promptText = $(prompt).find(".formErrorContent").html();
 


### PR DESCRIPTION
This is a simple fix to make sure the prompt position is updated for the
prettySelect (Select2 specifically) when the screen resizes and make
sure the prompt is positioned against the correct displayed element.
