### PR TITLE
Typo preventing the script from loading

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1,4 +1,4 @@
-2/*
+/*
  * Inline Form Validation Engine 2.6.1, jQuery plugin
  *
  * Copyright(c) 2010, Cedric Dugas


### PR DESCRIPTION
A "2" has made its way at the very beginning of the main script in revision 0bb6e7211570babae86df8f086c2593fc2ea76b3 (a few days ago). Unfortunately, this prevents the script from being loaded.

I'm not sure if this is worth a pull-request, but if it makes things easier, here it is.
