### PR TITLE
Better email validation

### DIFF
--- a/js/languages/jquery.validationEngine-en.js
+++ b/js/languages/jquery.validationEngine-en.js
@@ -82,7 +82,7 @@
                 },
                 "email": {
                     // HTML5 compatible email regex ( http://www.whatwg.org/specs/web-apps/current-work/multipage/states-of-the-type-attribute.html#    e-mail-state-%28type=email%29 )
-                    "regex": /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,
+                    "regex": /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
                     "alertText": "* Invalid email address"
                 },
                 "integer": {


### PR DESCRIPTION
Currently "123@gmail" validates as true. The new regex fixes that.
Source: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
