### PR TITLE
Fixed Custom Error Messages dealing with the 'custom' and 'funcCall' rules.

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -798,8 +798,11 @@
 				 var custom_validation_type = rules[rule_index + 1];
 				 rule = rule + "[" + custom_validation_type + "]";
 			 }
-			 // Change the rule to the composite rule, if it was different from the original
+			 // Change the rule to the composite rule, if it was different from the original,
+			 // and delete the rule from the rules array so that it doesn't try to call the
+			 // same rule over again
 			 var alteredRule = rule;
+			 delete(rules[rule_index]);
 
 
 			 var element_classes = (field.attr("data-validation-engine")) ? field.attr("data-validation-engine") : field.attr("class");


### PR DESCRIPTION
The _getErrorMessage method was not creating a composite rule lookup for custom messages, such as 'custom[phone]' like it said it was in the documentation. So I whipped up this patch to make it work. Now, instead of it looking to only find the 'custom' or 'funcCall' messages, it will grab the correct composite rule message.
I added the 'delete(rules[rule_index])' on line 805 because without it, the same custom validation composite would be used for all of the custom validations following it.
