### PR TITLE
Final fix for the custom[url] issue

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -797,12 +797,12 @@
 			 if (rule === "custom" || rule === "funcCall") {
 				 var custom_validation_type = rules[rule_index + 1];
 				 rule = rule + "[" + custom_validation_type + "]";
+				 // Delete the rule from the rules array so that it doesn't try to call the
+			    // same rule over again
+			    delete(rules[rule_index]);
 			 }
-			 // Change the rule to the composite rule, if it was different from the original,
-			 // and delete the rule from the rules array so that it doesn't try to call the
-			 // same rule over again
+			 // Change the rule to the composite rule, if it was different from the original
 			 var alteredRule = rule;
-			 delete(rules[rule_index]);
 
 
 			 var element_classes = (field.attr("data-validation-engine")) ? field.attr("data-validation-engine") : field.attr("class");


### PR DESCRIPTION
So I was in a bit of a rush earlier today when I submitted that patch, so I didn't catch a pretty big bug that was pointed out to me on one of my [commits](https://github.com/SamJBarney/jQuery-Validation-Engine/commit/3f5cb4f77c78c9bde12335744af4b15124af340c).
Because the delete is being called every time a rule goes through, it causes an error when the array has no elements and is passed to any function called within _getErrorMessage. This fixes that by placing the delete into the if statement so that it only gets called when there is a 'custom' or a 'funcCall'.
Once again, sorry about the mixups. It's been a pretty hectic day.
