### PR TITLE
Validating Non-Visible Fields

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -492,7 +492,7 @@
 				++$.validationEngine.fieldIdCounter;
 			}
 
-			if (field.is(":hidden") && !options.prettySelect || field.parent().is(":hidden"))
+           if (!options.validateNonVisibleFields && (field.is(":hidden") && !options.prettySelect || field.parent().is(":hidden")))
 				return false;
 
 			var rulesParsing = field.attr(options.validateAttribute);
@@ -1892,6 +1892,8 @@
 		focusFirstField:true,
 		// Show prompts, set to false to disable prompts
 		showPrompts: true,
+       // Should we attempt to validate non-visible input fields contained in the form? (Useful in cases of tabbed containers, e.g. jQuery-UI tabs)
+       validateNonVisibleFields: false,
 		// Opening box position, possible locations are: topLeft,
 		// topRight, bottomLeft, centerRight, bottomRight
 		promptPosition: "topRight",


### PR DESCRIPTION
In some cases, it is useful to be able to validate hidden fields in a form.
This is particularly true in the case of jquery-UI tabs, if you have a single form split over multiple tabs.
By adding an option about whether we want to validate hidden fields in a form, we can override the default behaviour when we need to, while at the same time maintaining the original behaviour by default.
