### PR TITLE
Custom Prompt class based on the HTML5  "data-required-class" attribute.

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1581,6 +1581,21 @@
 			if (options.addPromptClass)
 				prompt.addClass(options.addPromptClass);
 
+            // Add custom prompt class defined in element
+            var requiredOverride = field.attr('data-required-class');
+            if(requiredOverride !== undefined) {
+                prompt.addClass(requiredOverride);
+            } else {
+                if(options.prettySelect) {
+                    if($('#' + field.attr('id')).next().is('select')) {
+                        var prettyOverrideClass = $('#' + field.attr('id').substr(options.usePrefix.length).substring(options.useSuffix.length)).attr('data-required-class');
+                        if(prettyOverrideClass !== undefined) {
+                            prompt.addClass(prettyOverrideClass);
+                        }
+                    }
+                }
+            }
+
 			prompt.css({
 				"opacity": 0
 			});


### PR DESCRIPTION
I was doing a project where I needed multi-tiered required fields. So "red" was for primary then I made more classes for "secondary / tertiary" etc. So that when the whole form was validated, the "required" alerts were all different depending on the class defined in the "data-required-class" attribute. Thought
it might be useful to others as well. 

Also added in support for prettySelect.
