### PR TITLE
Some small fix for Russian dates

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1488,6 +1488,10 @@
 			var dateParts = d.split("-");
 			if(dateParts==d)
 				dateParts = d.split("/");
+			if(dateParts==d) {
+				dateParts = d.split(".");
+				return new Date(dateParts[2], (dateParts[1] - 1), dateParts[0]);
+			}
 			return new Date(dateParts[0], (dateParts[1] - 1) ,dateParts[2]);
 		},
 		/**


### PR DESCRIPTION
In Russia date format is "DD.MM.YYYY", so I've added it to _parseDate().

Now past and future filters can work.
