### PR TITLE
Possible fix to issue #608

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1432,6 +1432,7 @@
 								 if (options.showPrompts) methods._showPrompt(errorField, msg, "", true, options);
 							 } else {
 								 options.ajaxValidCache[errorFieldId] = true;
+								 options.isError = false;
 
 								 // resolves the msg prompt
 								 if(msg) {


### PR DESCRIPTION
When validating a form with Ajax field validation and binding the _jqv.field.result_ to monitor validation changes and alter for example the class of the field using jQuery, currently, the status will stay like there was an error, even if the Ajax check succeeded. 

This fix **seems** to solve the issue without breaking the script logics.

I offer then this possible bugfix.
