### PR TITLE
validate function returns true if field validates

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -134,7 +134,7 @@
 				// field validation
 				var form = element.closest('form, .validationEngineContainer'),
 					options = (form.data('jqv')) ? form.data('jqv') : $.validationEngine.defaults,
-					valid = methods._validateField(element, options);
+					valid = !methods._validateField(element, options);
 
 				if (valid && options.onFieldSuccess)
 					options.onFieldSuccess();


### PR DESCRIPTION
According to inline docs `_validateField` returns `flase` if field is valid, so it should be negated for `validate` to be consistent
