### PR TITLE
Added ability to adjust what element a fields prompt is shown on (useful...

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -342,9 +342,18 @@
 					errorFound |= methods._validateField(field, options);
 					if (errorFound && first_err==null)
 						if (field.is(":hidden") && options.prettySelect)
-										 first_err = field = form.find("#" + options.usePrefix + methods._jqSelector(field.attr('id')) + options.useSuffix);
-									else
-										 first_err=field;
+							first_err = field = form.find("#" + options.usePrefix + methods._jqSelector(field.attr('id')) + options.useSuffix);
+						else {
+
+							//Check if we need to adjust what element to show the prompt on
+							//and and such scroll to instead
+							if(field.data('jqv-prompt-at') instanceof jQuery ){
+								field = field.data('jqv-prompt-at');
+							} else if(field.data('jqv-prompt-at')) {
+								field = $(field.data('jqv-prompt-at'));
+							}
+							first_err=field;
+						}
 					if (options.doNotShowAllErrosOnSubmit)
 						return false;
 					names.push(field.attr('name'));
@@ -1510,6 +1519,13 @@
 		* @param {Map} options user options
 		*/
 		 _showPrompt: function(field, promptText, type, ajaxed, options, ajaxform) {
+		 	//Check if we need to adjust what element to show the prompt on
+			if(field.data('jqv-prompt-at') instanceof jQuery ){
+				field = field.data('jqv-prompt-at');
+			} else if(field.data('jqv-prompt-at')) {
+				field = $(field.data('jqv-prompt-at'));
+			}
+
 			 var prompt = methods._getPrompt(field);
 			 // The ajax submit errors are not see has an error in the form,
 			 // When the form errors are returned, the engine see 2 bubbles, but those are ebing closed by the engine at the same time


### PR DESCRIPTION
Adds the ability to redirect the prompt on a per-field basis.

It uses the `jqv-prompt-at` data attribute (attribute name may need to be changed to fit more with the plugin).

This feature is useful when validating hidden inputs, you may want to display the prompt on another element, or in my case, I have a plugin that hides the original input that gets validated, it then displays whatever is typed in with a mask. as such we do not want to validate the clone, but we want to prompt when the actual value does not validate shown on the clone.

This works in two ways.
**It can either be used with an ID**

```
<input name="something" class="validate[custom[numeric]]" data-jqv-prompt-at="#elementClone" />

//or after initialization

$('[name="something"]').data('jqv-prompt-at', '#elementClone');
```

**or with a full jquery object**

```
//some random selector chain to show how it's useful!
var $selector = $('#elementClonesParent'),children().first();
$('[name="something"]').data('jqv-prompt-at', $selector);
```
