### PR TITLE
Fix handler name to off

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -84,10 +84,7 @@
 			form.find("["+options.validateAttribute+"*=validate][type=checkbox],[class*=validate][type=radio]").off("click", methods._onFieldEvent);
 
 			// unbind form.submit
-			form.off("submit", methods.onAjaxFormComplete);
-
-			// unbind form.submit
-			form.off("submit", methods.onAjaxFormComplete);
+			form.off("submit", methods._onSubmitEvent);
 			form.removeData('jqv');
             
 			form.off("click", "a[data-validation-engine-skip], a[class*='validate-skip'], button[data-validation-engine-skip], button[class*='validate-skip'], input[data-validation-engine-skip], input[class*='validate-skip']", methods._submitButtonClick);


### PR DESCRIPTION
Hi,

Could you consider to merge this change?
When the plugin is detached from elements, it tries to detach the handlers, but the handler actually doesn't exist and call `off` method with undefined handler. It causes detaching all the handler attached to this element.
