### PR TITLE
equals should be validated even empty

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -704,7 +704,10 @@
 				}	
 			}
 			// If the rules required is not added, an empty field is not validated
-			if(!required && !(field.val()) && field.val().length < 1) options.isError = false;
+			//the 3rd condition is added so that even empty password fields should be equal
+			//otherwise if one is filled and another left empty, the "equal" condition would fail
+			//which does not make any sense
+			if(!required && !(field.val()) && field.val().length < 1 && rules.indexOf("equals") < 0) options.isError = false;
 
 			// Hack for radio/checkbox group button, the validation go into the
 			// first radio/checkbox of the group


### PR DESCRIPTION
I ran into this when validating passwords.
When editting user profile, it's optional to leave the passwords empty (no-change required), a normal method.

Intended password conditions: "validate[equals[password]]", note there is no "required"! because it's optional!!!

The current version fails to validate such requests as it ignores the "equals" error because the "field.val().length < 1" condition. which is fine for most cases but not for the passwords.

So I added another condition (a 3rd condition) so that even empty password fields should be equal
otherwise if one is filled and another left empty, the "equal" condition would fail
which does not make any sense.

Hope it makes sense to you all.
