### PR TITLE
Missing promptPosition: 'inline'

### DIFF
--- a/demos/demoInlineMessages.html
+++ b/demos/demoInlineMessages.html
@@ -14,7 +14,7 @@
 	<script>
 		jQuery(document).ready(function(){
 			// binds form submission and fields to the validation engine
-			jQuery("#formID").validationEngine();
+			jQuery("#formID").validationEngine({promptPosition: 'inline'});
 		});
 
 		/**


### PR DESCRIPTION
Because this demo is for demonstrating inline messages I believe the promptPosition should be set to 'inline' which it currently isn't
