### PR TITLE
Add the `showArrowOnRadioAndCheckbox` option, and change the positioning calculus a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ Determines if the prompt should hide itself automatically after a set period. De
 ### autoHideDelay
 Sets the number of ms that the prompt should appear for if autoHidePrompt is set to *true*. Defaults to *10000*. 
 
+### showArrow
+Show the arrow in the validation popup. Defaults to *true*
+
+### showArrowOnRadioAndCheckbox
+Show the arrow in the validation popup when validating checkboxes and radio buttons. Defaults to *false*
+
 Validators
 ---
 

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -724,7 +724,7 @@
 				} else {
 				field = $(form.find("input[name='" + fieldName + "'][type!=hidden]:first"));
 				}
-				options.showArrow = false;
+				options.showArrow = options.showArrowOnRadioAndCheckbox;
 			}
 
 			if(field.is(":hidden") && options.prettySelect) {
@@ -1832,7 +1832,7 @@
 			switch (positionType) {
 				default:
 				case "topRight":
-					promptleftPosition +=  fieldLeft + fieldWidth - 30;
+					promptleftPosition +=  fieldLeft + fieldWidth - 27;
 					promptTopPosition +=  fieldTop;
 					break;
 
@@ -1859,7 +1859,7 @@
 					promptleftPosition = fieldLeft;
 					break;
 				case "bottomRight":
-					promptleftPosition = fieldLeft + fieldWidth - 30;
+					promptleftPosition = fieldLeft + fieldWidth - 27;
 					promptTopPosition =  fieldTop +  field.height() + 5;
 					marginTopSize = 0;
 					break;
@@ -2034,6 +2034,9 @@
 		binded: true,
 		// set to true, when the prompt arrow needs to be displayed
 		showArrow: true,
+		// set to false, determines if the prompt arrow should be displayed when validating
+		// checkboxes and radio buttons
+		showArrowOnRadioAndCheckbox: false,
 		// did one of the validation fail ? kept global to stop further ajax validations
 		isError: false,
 		// Limit how many displayed errors a field can have


### PR DESCRIPTION
- Add the `showArrowOnRadioAndCheckbox` option to allow showing the popup arrow on validation
- Add `showArrow` to the documentation
- Use 27 instead of 30 for the offset to better center the element on radio buttons and checkboxes
