### PR TITLE
Fix: Null-value fields; checkbox condRequired/groupRequired; groupRequired recursion, noAnimation

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -553,7 +553,9 @@
 				rules[i] = rules[i].replace(" ", "");
 				// Remove any parsing errors
 				if (rules[i] === '') {
-					delete rules[i];
+					// Remove the element from the array and step the counter back to account for smaller array
+					rules.splice(i,1);
+					i--;
 				}
 			}
 
@@ -582,15 +584,16 @@
 						errorMsg = methods._getErrorMessage(form, field, rules[i], rules, i, options, methods._custom);
 						break;
 					case "groupRequired":
-						// Check is its the first of group, if not, reload validation with first field
-						// AND continue normal validation on present field
+						// Check to see if we should start an iterative check on all groupRequired elements
+						// or we're in the middle of one already and should test validation on the current iterated field
 						var classGroup = "["+options.validateAttribute+"*=" +rules[i + 1] +"]";
-						var firstOfGroup = form.find(classGroup).eq(0);
-						if(firstOfGroup[0] != field[0]){
-
-							methods._validateField(firstOfGroup, options, skipAjaxValidation); 
-							options.showArrow = true;
-
+						if (!('GroupRequiredFields' in options)) {
+							options.GroupRequiredFields = form.find(classGroup);
+							for (var j = 0; j < options.GroupRequiredFields.length; j++) {
+								methods._validateField(options.GroupRequiredFields.eq(j), options, skipAjaxValidation);
+							}
+							if (options.GroupRequiredFields.length > 1) options.showArrow = true;
+							delete options.GroupRequiredFields;
 						}
 						errorMsg = methods._getErrorMessage(form, field, rules[i], rules, i, options, methods._groupRequired);
 						if(errorMsg)  required = true;

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -86,7 +86,7 @@
 			// unbind form.submit
 			form.off("submit", methods._onSubmitEvent);
 			form.removeData('jqv');
-            
+
 			form.off("click", "a[data-validation-engine-skip], a[class*='validate-skip'], button[data-validation-engine-skip], button[class*='validate-skip'], input[data-validation-engine-skip], input[class*='validate-skip']", methods._submitButtonClick);
 			form.removeData('jqv_submitButton');
 
@@ -110,7 +110,7 @@
 					// form is already validating.
 					// Should abort old validation and start new one. I don't know how to implement it.
 					return false;
-				} else {				
+				} else {
 					element.addClass('validating');
 					var options = element.data('jqv');
 					var valid = methods._validateFields(this);
@@ -149,15 +149,17 @@
 		*  Redraw prompts position, useful when you change the DOM state when validating
 		*/
 		updatePromptsPosition: function(event) {
+			var noAnimation;
 
 			if (event && this == window) {
 				var form = event.data.formElem;
-				var noAnimation = event.data.noAnimation;
+				noAnimation = event.data.noAnimation;
 			}
 			else
 				var form = $(this.closest('form, .validationEngineContainer'));
 
 			var options = form.data('jqv');
+			noAnimation = noAnimation || options.noAnimation;
 			// No option, take default one
 			form.find('['+options.validateAttribute+'*=validate]').not(":disabled").each(function(){
 				var field = $(this);
@@ -200,7 +202,7 @@
 			 var options = form.data('jqv');
 			 var fadeDuration = (options && options.fadeDuration) ? options.fadeDuration : 0.3;
 			 var closingtag;
-			 
+
 			 if($(this).is("form") || $(this).hasClass("validationEngineContainer")) {
 				 closingtag = "parentForm"+methods._getClassName($(this).attr("id"));
 			 } else {
@@ -256,7 +258,7 @@
 		_onSubmitEvent: function() {
 			var form = $(this);
 			var options = form.data('jqv');
-			
+
 			//check if it is trigger from skipped button
 			if (form.data("jqv_submitButton")){
 				var submitButton = $("#" + form.data("jqv_submitButton"));
@@ -270,7 +272,7 @@
 
 			options.eventTrigger = "submit";
 
-			// validate each field 
+			// validate each field
 			// (- skip field ajax validation, not necessary IF we will perform an ajax form validation)
 			var r=methods._validateFields(form);
 
@@ -302,7 +304,7 @@
 			});
 			return status;
 		},
-		
+
 		/**
 		* Return true if the ajax field is validated
 		* @param {String} fieldid
@@ -384,7 +386,7 @@
 							destination=prompt_err.offset().top;
 						}
 					}
-					
+
 					// Offset the amount the page scrolls by an amount in px to accomodate fixed elements at top of page
 					if (options.scrollOffset) {
 						destination -= options.scrollOffset;
@@ -541,7 +543,7 @@
 			var limitErrors = false;
 			options.isError = false;
 			options.showArrow = true;
-			
+
 			// If the programmer wants to limit the amount of error messages per field,
 			if (options.maxErrorsPerField > 0) {
 				limitErrors = true;
@@ -560,7 +562,7 @@
 			}
 
 			for (var i = 0, field_errors = 0; i < rules.length; i++) {
-				
+
 				// If we are limiting errors, and have hit the max, break
 				if (limitErrors && field_errors >= options.maxErrorsPerField) {
 					// If we haven't hit a required yet, check to see if there is one in the validation rules for this
@@ -571,8 +573,8 @@
 					}
 					break;
 				}
-				
-				
+
+
 				var errorMsg = undefined;
 				switch (rules[i]) {
 
@@ -675,9 +677,9 @@
 
 					default:
 				}
-				
+
 				var end_validation = false;
-				
+
 				// If we were passed back an message object, check what the status was to determine what to do
 				if (typeof errorMsg == "object") {
 					switch (errorMsg.status) {
@@ -697,18 +699,18 @@
 							break;
 					}
 				}
-				
+
 				// If it has been specified that validation should end now, break
 				if (end_validation) {
 					break;
 				}
-				
+
 				// If we have a string, that means that we have an error, so add it to the error message.
 				if (typeof errorMsg == 'string') {
 					promptText += errorMsg + "<br/>";
 					options.isError = true;
 					field_errors++;
-				}	
+				}
 			}
 			// If the rules required is not added, an empty field is not validated
 			//the 3rd condition is added so that even empty password fields should be equal
@@ -752,9 +754,9 @@
 			} else if (!options.isError) {
 				options.InvalidFields.splice(errindex, 1);
 			}
-				
+
 			methods._handleStatusCssClasses(field, options);
-	
+
 			/* run callback function for each field */
 			if (options.isError && options.onFieldFailure)
 				options.onFieldFailure(field);
@@ -765,30 +767,30 @@
 			return options.isError;
 		},
 		/**
-		* Handling css classes of fields indicating result of validation 
+		* Handling css classes of fields indicating result of validation
 		*
 		* @param {jqObject}
 		*            field
 		* @param {Array[String]}
-		*            field's validation rules            
+		*            field's validation rules
 		* @private
 		*/
 		_handleStatusCssClasses: function(field, options) {
 			/* remove all classes */
 			if(options.addSuccessCssClassToField)
 				field.removeClass(options.addSuccessCssClassToField);
-			
+
 			if(options.addFailureCssClassToField)
 				field.removeClass(options.addFailureCssClassToField);
-			
+
 			/* Add classes */
 			if (options.addSuccessCssClassToField && !options.isError)
 				field.addClass(options.addSuccessCssClassToField);
-			
+
 			if (options.addFailureCssClassToField && options.isError)
-				field.addClass(options.addFailureCssClassToField);		
+				field.addClass(options.addFailureCssClassToField);
 		},
-		
+
 		 /********************
 		  * _getErrorMessage
 		  *
@@ -845,12 +847,12 @@
 			if (validityProp != undefined) {
 				custom_message = field.attr("data-errormessage-"+validityProp);
 				// If there was an error message for it, return the message
-				if (custom_message != undefined) 
+				if (custom_message != undefined)
 					return custom_message;
 			}
 			custom_message = field.attr("data-errormessage");
 			 // If there is an inline custom error message, return it
-			if (custom_message != undefined) 
+			if (custom_message != undefined)
 				return custom_message;
 			var id = '#' + field.attr("id");
 			// If we have custom messages for the element's id, get the message for the rule from the id.
@@ -966,7 +968,7 @@
 					isValid = true;
 					return false;
 				}
-			}); 
+			});
 
 			if(!isValid) {
 		  return options.allrules[rules[i]].alertText;
@@ -990,7 +992,7 @@
 				alert("jqv:custom rule not found - "+customRule);
 				return;
 			}
-			
+
 			if(rule["regex"]) {
 				 var ex=rule.regex;
 					if(!ex) {
@@ -1000,15 +1002,15 @@
 					var pattern = new RegExp(ex);
 
 					if (!pattern.test(field.val())) return options.allrules[customRule].alertText;
-					
+
 			} else if(rule["func"]) {
-				fn = rule["func"]; 
-				 
+				fn = rule["func"];
+
 				if (typeof(fn) !== "function") {
 					alert("jqv:custom parameter 'function' is no function - "+customRule);
 						return;
 				}
-				 
+
 				if (!fn(field, rules, i, options))
 					return options.allrules[customRule].alertText;
 			} else {
@@ -1394,7 +1396,7 @@
 					 }
 				 }
 			 }
-			 
+
 			 // If a field change event triggered this we want to clear the cache for this ID
 			 if (options.eventTrigger == "field") {
 				delete(options.ajaxValidCache[field.attr("id")]);
@@ -1472,7 +1474,7 @@
 									 else
 										methods._closePrompt(errorField);
 								}
-								
+
 								 // If a submit form triggered this, we want to re-submit the form
 								 if (options.eventTrigger == "submit")
 									field.closest("form").submit();
@@ -1481,7 +1483,7 @@
 						 errorField.trigger("jqv.field.result", [errorField, options.isError, msg]);
 					 }
 				 });
-				 
+
 				 return rule.alertTextLoad;
 			 }
 		 },
@@ -1543,7 +1545,7 @@
 			 // Because no error was found befor submitting
 			 if(ajaxform) prompt = false;
 			 // Check that there is indded text
-			 if($.trim(promptText)){ 
+			 if($.trim(promptText)){
 				 if (prompt)
 					methods._updatePrompt(field, prompt, promptText, type, ajaxed, options);
 				 else
@@ -1594,7 +1596,7 @@
 				var arrow = $('<div>').addClass("formErrorArrow");
 
 				//prompt positioning adjustment support. Usage: positionType:Xshift,Yshift (for ex.: bottomLeft:+20 or bottomLeft:-20,+10)
-				if (typeof(positionType)=='string') 
+				if (typeof(positionType)=='string')
 				{
 					var pos=positionType.indexOf(":");
 					if(pos!=-1)
@@ -1644,9 +1646,9 @@
 					field.after(prompt);
 				}
 			} else {
-				field.before(prompt);				
+				field.before(prompt);
 			}
-			
+
 			var pos = methods._calculatePosition(field, prompt, options);
 			prompt.css({
 				'position': positionType === 'inline' ? 'relative' : 'absolute',
@@ -1655,7 +1657,7 @@
 				"marginTop": pos.marginTopSize,
 				"opacity": 0
 			}).data("callerField", field);
-			
+
 
 			if (options.autoHidePrompt) {
 				setTimeout(function(){
@@ -1666,7 +1668,7 @@
 						prompt.remove();
 					});
 				}, options.autoHideDelay);
-			} 
+			}
 			return prompt.animate({
 				"opacity": 0.87
 			});
@@ -1784,9 +1786,9 @@
 
 			var promptTopPosition, promptleftPosition, marginTopSize;
 			var fieldWidth 	= field.width();
-			var fieldLeft 	= field.position().left; 
+			var fieldLeft 	= field.position().left;
 			var fieldTop 	=  field.position().top;
-			var fieldHeight 	=  field.height();	
+			var fieldHeight 	=  field.height();
 			var promptHeight = promptElmt.height();
 
 
@@ -1794,7 +1796,7 @@
 			promptTopPosition = promptleftPosition = 0;
 			// compensation for the arrow
 			marginTopSize = -promptHeight;
-		
+
 
 			//prompt positioning adjustment support
 			//now you can adjust prompt position
@@ -1831,7 +1833,7 @@
 				};
 			};
 
-			
+
 			switch (positionType) {
 				default:
 				case "topRight":
@@ -1841,7 +1843,7 @@
 
 				case "topLeft":
 					promptTopPosition +=  fieldTop;
-					promptleftPosition += fieldLeft; 
+					promptleftPosition += fieldLeft;
 					break;
 
 				case "centerRight":
@@ -1853,7 +1855,7 @@
 					promptleftPosition = fieldLeft - (promptElmt.width() + 2);
 					promptTopPosition = fieldTop+4;
 					marginTopSize = 0;
-					
+
 					break;
 
 				case "bottomLeft":
@@ -1872,7 +1874,7 @@
 					marginTopSize = 0;
 			};
 
-		
+
 
 			//apply adjusments if any
 			promptleftPosition += shiftX;
@@ -2041,7 +2043,7 @@
 		isError: false,
 		// Limit how many displayed errors a field can have
 		maxErrorsPerField: false,
-		
+
 		// Caches field validation status, typically only bad status are created.
 		// the array is used during ajax form validation to detect issues early and prevent an expensive submit
 		ajaxValidCache: {},
@@ -2056,7 +2058,7 @@
 		validateAttribute: "class",
 		addSuccessCssClassToField: "",
 		addFailureCssClassToField: "",
-		
+
 		// Auto-hide prompt
 		autoHidePrompt: false,
 		// Delay before auto-hide

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -711,7 +711,7 @@
 			//the 3rd condition is added so that even empty password fields should be equal
 			//otherwise if one is filled and another left empty, the "equal" condition would fail
 			//which does not make any sense
-			if(!required && !(field.val()) && field.val().length < 1 && rules.indexOf("equals") < 0) options.isError = false;
+			if ( !required && (!field.val() || field.val().length < 1) && rules.indexOf("equals") < 0) options.isError = false;
 
 			// Hack for radio/checkbox group button, the validation go into the
 			// first radio/checkbox of the group

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -927,7 +927,7 @@
 				case "checkbox":
 					// new validation style to only check dependent field
 					if (condRequired) {
-						if (!field.attr('checked')) {
+						if (!field.is(':checked')) {
 							return options.allrules[rules[i]].alertTextCheckboxMultiple;
 						}
 						break;

--- a/js/languages/jquery.validationEngine-en.js
+++ b/js/languages/jquery.validationEngine-en.js
@@ -39,7 +39,8 @@
                 },
 				"groupRequired": {
                     "regex": "none",
-                    "alertText": "* You must fill one of the following fields"
+                    "alertText": "* You must fill one of the following fields",
+                    "alertTextCheckboxe": "* You must fill one of the following fields"
                 },
                 "min": {
                     "regex": "none",


### PR DESCRIPTION
Null values are caused when validation is run on a &lt;select&gt; element with either no &lt;option&gt;s or a disabled &lt;option&gt; is selected (by default on a page load, not because the user selected a disabled &lt;option&gt;!). Disabled &lt;option&gt;s are used as initial &lt;select&gt; field states and act in a manner similar to &lt;input&gt; placeholders. These elements have a null-value, as opposed to blank &lt;input&gt; fields that have an empty-string value.

For condRequired in which the target is a checkbox, the buggy code only would look for the existence of a "checked" attribute. But this attribute would not exist if the initial state of the checkbox (on page load) was unchecked. The syntax has been updated to determine whether the checkbox is actually checked, regardless of the existence of the "checked" attribute.

Checkbox support has been added for groupRequired. The code currently looks for the existence of alertTextCheckboxe inside the groupRequired options array in order to trigger groupRequired involving a checkbox, and so I've added an entry to the English language file. I realize that this is not a really optimal solution since all other language files need to be updated.

Finally the groupRequired condition has been reworked so that it's no longer doing a recursive call to validateField() in a way that prevents validation notification refresh to subsequent fields. Let's say you have 3 fields in a groupRequired configuration (and you can look at the latest demo to see this), and then leave it all blank and attempt to submit, triggering a tooltip notification on all the fields. If you change the value of the first one, the 2nd and 3rd fields' tooltip do not go away. The revision was to create an array GroupRequiredFields inside the "options" object and to check for the existence of that property-array in order to start the iteration of recursive validation calls, except instead of relying on base case that the current field context is not the first field in the group, we test for the existence of GroupRequiredFields (if it exists, we skip over the iteration loop so we don't iterate again and proceed to validate the current field as normal).
