### PR TITLE
Fixed binded documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Name of the event triggering field validation, defaults to *blur*.
 Determines if we should scroll the page to the first error, defaults to *true*.
 
 ### binded
-If set to true, it remove blur events and only validate on submit.
+If set to false, it removes blur events and only validates on submit.
 
 ### promptPosition
 Where should the prompt show? Possible values are "topLeft", "topRight", "bottomLeft", "centerRight", "bottomRight". Defaults to *"topRight"*.

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -2030,7 +2030,7 @@
 		doNotShowAllErrosOnSubmit: false,
 		// Object where you store custom messages to override the default error messages
 		custom_error_messages:{},
-		// true if you want to vind the input fields
+		// true if you want to validate the input fields on blur event
 		binded: true,
 		// set to true, when the prompt arrow needs to be displayed
 		showArrow: true,


### PR DESCRIPTION
Binded is documented wrong, when binded is set to false the blur event validation is canceled, unlike it's written in the documentation and in the code comments
