### PR TITLE
Fixed binded documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Name of the event triggering field validation, defaults to *blur*.
 Determines if we should scroll the page to the first error, defaults to *true*.
 
 ### binded
-If set to true, it remove blur events and only validate on submit.
+If set to false, it removes blur events and only validates on submit.
 
 ### promptPosition
 Where should the prompt show? Possible values are "topLeft", "topRight", "bottomLeft", "centerRight", "bottomRight". Defaults to *"topRight"*.


### PR DESCRIPTION
Binded is documented wrong, when binded is set to false the blur event validation is canceled, unlike it's written in the documentation and in the code comments
