### PR TITLE
Fixes #739

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1471,7 +1471,7 @@
 								}
 								
 								 // If a submit form triggered this, we want to re-submit the form
-								 if (options.eventTrigger == "submit")
+								 if (this.options.eventTrigger == "submit")
 									field.closest("form").submit();
 							 }
 						 }


### PR DESCRIPTION
bug:
具有ajax验证功能的input，同时具有焦点，直接用鼠标点击提交按钮，会导致blur和submit验证同时触发（blur先）,而blur验证的opitons.eventTrigger 值会被submit事件覆盖，导致最终数据两次提交
  input（ajax、focus、current validation fails）,click submit.
  result：twice submit
