### PR TITLE
Fixing #737, for jQuery > 1.6: .attr() should be .prop() for properties

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -910,7 +910,7 @@
 				case "checkbox":
 					// new validation style to only check dependent field
 					if (condRequired) {
-						if (!field.attr('checked')) {
+						if (!field.prop('checked')) {
 							return options.allrules[rules[i]].alertTextCheckboxMultiple;
 						}
 						break;


### PR DESCRIPTION
To retrieve and change DOM properties such as the checked, selected, or disabled state of form elements, use the .prop() method.

Signed-off-by: Mafl fluer@vericom.at
