### PR TITLE
support jQuery object for options.overflownDiv

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -397,7 +397,7 @@
 						var scrollContainerPos = -parseInt(overflowDIV.offset().top);
 
 						destination += scrollContainerScroll + scrollContainerPos - 5;
-						var scrollContainer = $(options.overflownDIV + ":not(:animated)");
+						var scrollContainer = $(options.overflownDIV).filter(":not(:animated)");
 
 						scrollContainer.animate({ scrollTop: destination }, 1100, function(){
 							if(options.focusFirstField) first_err.focus();


### PR DESCRIPTION
Better to support jQuery object for options.overflownDiv. Becuase in many cases, the selector itself is not enough to select the element what i wanted.
