### PR TITLE
Fixes bug #836

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1718,6 +1718,11 @@
 				"marginTop": pos.marginTopSize,
 				"opacity": 0.87};
 
+                prompt.css({
+                    "opacity": 0,
+                    "display": "block"
+                });
+                
 				if (noAnimation)
 					prompt.css(css);
 				else


### PR DESCRIPTION
This fixes the bug #836.
As the "display" css rule cannot be animated we need to set it to "block" before the animation.
But, this would display the bubble ignoring animation. So we also need to set the opacity to 0.
