### PR TITLE
Ensure closing of prompt; new validation rule for dates in d/m/y format.

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -214,6 +214,8 @@
 
 			 if($(this).is("form") || $(this).hasClass("validationEngineContainer")) {
 				 closingtag = "parentForm"+methods._getClassName($(this).attr("id"));
+			 } else if ($(this).is("select") && options.prettySelect && $(this).is(":hidden")) {
+				 closingtag = methods._getClassName(options.usePrefix + $(this).attr('id') + options.useSuffix) +"formError";
 			 } else {
 				 closingtag = methods._getClassName($(this).attr("id")) +"formError";
 			 }

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -1767,6 +1767,11 @@
 		*            field
 		*/
 		 _closePrompt: function(field) {
+			 if(field.data('jqv-prompt-at') instanceof jQuery ){
+				 field = field.data('jqv-prompt-at');
+			 } else if(field.data('jqv-prompt-at')) {
+				 field = $(field.data('jqv-prompt-at'));
+			 }
 			 var prompt = methods._getPrompt(field);
 			 if (prompt)
 				 prompt.fadeTo("fast", 0, function() {

--- a/js/languages/jquery.validationEngine-en.js
+++ b/js/languages/jquery.validationEngine-en.js
@@ -106,20 +106,37 @@
                 },
                 "date": {                    
                     //	Check if date is valid by leap year
-			"func": function (field) {
-					var pattern = new RegExp(/^(\d{4})[\/\-\.](0?[1-9]|1[012])[\/\-\.](0?[1-9]|[12][0-9]|3[01])$/);
-					var match = pattern.exec(field.val());
-					if (match == null)
-					   return false;
+					"func": function (field) {
+							var pattern = new RegExp(/^(\d{4})[\/\-\.](0?[1-9]|1[012])[\/\-\.](0?[1-9]|[12][0-9]|3[01])$/);
+							var match = pattern.exec(field.val());
+							if (match == null)
+							   return false;
 	
-					var year = match[1];
-					var month = match[2]*1;
-					var day = match[3]*1;					
-					var date = new Date(year, month - 1, day); // because months starts from 0.
+							var year = match[1];
+							var month = match[2]*1;
+							var day = match[3]*1;					
+							var date = new Date(year, month - 1, day); // because months starts from 0.
 	
-					return (date.getFullYear() == year && date.getMonth() == (month - 1) && date.getDate() == day);
-				},                		
-			 "alertText": "* Invalid date, must be in YYYY-MM-DD format"
+							return (date.getFullYear() == year && date.getMonth() == (month - 1) && date.getDate() == day);
+						},                		
+					 "alertText": "* Invalid date, must be in YYYY-MM-DD format"
+                },
+                "date_dmy": {                    
+                    //	Check if date is valid by leap year
+					"func": function (field) {
+							var pattern = new RegExp(/^(0?[1-9]|[12][0-9]|3[01])[\/\-\.](0?[1-9]|1[012])[\/\-\.](\d{4})$/);
+							var match = pattern.exec(field.val());
+							if (match == null)
+							   return false;
+	
+							var day = match[1]*1;					
+							var month = match[2]*1;
+							var year = match[3];
+							var date = new Date(year, month - 1, day); // because months starts from 0.
+	
+							return (date.getFullYear() == year && date.getMonth() == (month - 1) && date.getDate() == day);
+						},                		
+					 "alertText": "* Invalid date, must be in DD-MM-YYYY format"
                 },
                 "ipv4": {
                     "regex": /^((([01]?[0-9]{1,2})|(2[0-4][0-9])|(25[0-5]))[.]){3}(([0-1]?[0-9]{1,2})|(2[0-4][0-9])|(25[0-5]))$/,

--- a/js/languages/jquery.validationEngine-en.js
+++ b/js/languages/jquery.validationEngine-en.js
@@ -105,38 +105,38 @@
                     "alertText": "* Invalid floating decimal number"
                 },
                 "date": {                    
-                    //	Check if date is valid by leap year
-					"func": function (field) {
-							var pattern = new RegExp(/^(\d{4})[\/\-\.](0?[1-9]|1[012])[\/\-\.](0?[1-9]|[12][0-9]|3[01])$/);
-							var match = pattern.exec(field.val());
-							if (match == null)
-							   return false;
-	
-							var year = match[1];
-							var month = match[2]*1;
-							var day = match[3]*1;					
-							var date = new Date(year, month - 1, day); // because months starts from 0.
-	
-							return (date.getFullYear() == year && date.getMonth() == (month - 1) && date.getDate() == day);
-						},                		
-					 "alertText": "* Invalid date, must be in YYYY-MM-DD format"
+                    //  Check if date is valid by leap year
+                    "func": function (field) {
+                            var pattern = new RegExp(/^(\d{4})[\/\-\.](0?[1-9]|1[012])[\/\-\.](0?[1-9]|[12][0-9]|3[01])$/);
+                            var match = pattern.exec(field.val());
+                            if (match == null)
+                               return false;
+    
+                            var year = match[1];
+                            var month = match[2]*1;
+                            var day = match[3]*1;                   
+                            var date = new Date(year, month - 1, day); // because months starts from 0.
+    
+                            return (date.getFullYear() == year && date.getMonth() == (month - 1) && date.getDate() == day);
+                        },                      
+                     "alertText": "* Invalid date, must be in YYYY-MM-DD format"
                 },
                 "date_dmy": {                    
-                    //	Check if date is valid by leap year
-					"func": function (field) {
-							var pattern = new RegExp(/^(0?[1-9]|[12][0-9]|3[01])[\/\-\.](0?[1-9]|1[012])[\/\-\.](\d{4})$/);
-							var match = pattern.exec(field.val());
-							if (match == null)
-							   return false;
-	
-							var day = match[1]*1;					
-							var month = match[2]*1;
-							var year = match[3];
-							var date = new Date(year, month - 1, day); // because months starts from 0.
-	
-							return (date.getFullYear() == year && date.getMonth() == (month - 1) && date.getDate() == day);
-						},                		
-					 "alertText": "* Invalid date, must be in DD-MM-YYYY format"
+                    //  Check if date is valid by leap year
+                    "func": function (field) {
+                            var pattern = new RegExp(/^(0?[1-9]|[12][0-9]|3[01])[\/\-\.](0?[1-9]|1[012])[\/\-\.](\d{4})$/);
+                            var match = pattern.exec(field.val());
+                            if (match == null)
+                               return false;
+    
+                            var day = match[1]*1;                   
+                            var month = match[2]*1;
+                            var year = match[3];
+                            var date = new Date(year, month - 1, day); // because months starts from 0.
+    
+                            return (date.getFullYear() == year && date.getMonth() == (month - 1) && date.getDate() == day);
+                        },                      
+                     "alertText": "* Invalid date, must be in DD-MM-YYYY format"
                 },
                 "ipv4": {
                     "regex": /^((([01]?[0-9]{1,2})|(2[0-4][0-9])|(25[0-5]))[.]){3}(([0-1]?[0-9]{1,2})|(2[0-4][0-9])|(25[0-5]))$/,


### PR DESCRIPTION
I found a couple of instances where prompts were not closing properly. First is for 'prettySelect' fields using a prefix or suffix; the class name used for the selector was wrong. The prefix/suffix need to be included in the class name. 

There was a similar issue with prompts attached with 'jqv-prompt-at' not closing.

Change to the jquery.validationEngine-en.js file is a new validation rule for dates in the dd/mm/yyyy format.