### PR TITLE
Trailing <br/> displayed literally in prompt

### DIFF
--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -730,7 +730,10 @@
 
 				//funcCallRequired, first in rules, and has error, skip anything else
 				if( i==0 && str.indexOf('funcCallRequired')==0 && errorMsg !== undefined ){
-					promptText += errorMsg + "<br/>";
+					if(promptText != '') {
+						promptText += "<br/>"
+					}
+					promptText += errorMsg;
 					options.isError=true;
 					field_errors++;
 					end_validation=true;
@@ -743,7 +746,10 @@
 
 				// If we have a string, that means that we have an error, so add it to the error message.
 				if (typeof errorMsg == 'string') {
-					promptText += errorMsg + "<br/>";
+					if(promptText != '') {
+						promptText += "<br/>"
+					}
+					promptText += errorMsg;
 					options.isError = true;
 					field_errors++;
 				}

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -731,7 +731,7 @@
 				//funcCallRequired, first in rules, and has error, skip anything else
 				if( i==0 && str.indexOf('funcCallRequired')==0 && errorMsg !== undefined ){
 					if(promptText != '') {
-						promptText += "<br/>"
+						promptText += "<br/>";
 					}
 					promptText += errorMsg;
 					options.isError=true;
@@ -747,7 +747,7 @@
 				// If we have a string, that means that we have an error, so add it to the error message.
 				if (typeof errorMsg == 'string') {
 					if(promptText != '') {
-						promptText += "<br/>"
+						promptText += "<br/>";
 					}
 					promptText += errorMsg;
 					options.isError = true;


### PR DESCRIPTION
I sometimes get a trailing &lt;br/> displayed 'literally' after the last error message.
The trailing line break is useless, so I created this patch to avoid it.

This does not solve the actual issue of line breaks getting displayed literally, but behaviour is inconsistent, so  I can't quickly reproduce this to debug.