### PR TITLE
Apply user options to per field validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /js/jquery.validationEngine.log.txt
 /js/jquery.validationEngine.js.min.js.log.txt
 /js/jquery.validationEngine-en.log.txt
+/.settings/
+/.gitignore
+/.project

--- a/js/jquery.validationEngine.js
+++ b/js/jquery.validationEngine.js
@@ -133,17 +133,21 @@
 				element.removeClass('validating');
 			} else {
 				// field validation
-		                var form = element.closest('form, .validationEngineContainer');
-		                options = (form.data('jqv')) ? form.data('jqv') : $.validationEngine.defaults;
-		                valid = methods._validateField(element, options);
-		
-		                if (valid && options.onFieldSuccess)
-		                    options.onFieldSuccess();
-		                else if (options.onFieldFailure && options.InvalidFields.length > 0) {
-		                    options.onFieldFailure();
-		                }
-		
-		                return !valid;
+                var form = element.closest('form, .validationEngineContainer');
+				if(userOptions) {
+					options = methods._mergeWithFormOptions(form, userOptions);
+				} else {
+	                options = (form.data('jqv')) ? form.data('jqv') : $.validationEngine.defaults;
+				}
+                valid = methods._validateField(element, options);
+
+                if (valid && options.onFieldSuccess)
+                    options.onFieldSuccess();
+                else if (options.onFieldFailure && options.InvalidFields.length > 0) {
+                    options.onFieldFailure();
+                }
+
+                return !valid;
 			}
 			if(options.onValidationComplete) {
 				// !! ensures that an undefined return is interpreted as return false but allows a onValidationComplete() to possibly return true and have form continue processing
@@ -1984,7 +1988,20 @@
 			 form.data('jqv', userOptions);
 			 return userOptions;
 		 },
-
+		/**
+		 * Merge the user options for field validation with the form validaton options or otherwise with the defaults
+		 *
+		 * @param {jqObject}
+		 *            form - the form where the user option should be saved
+		 * @param {Map}
+		 *            options - the user options
+		 * @return the user options (extended from the form options)
+		 */
+		 _mergeWithFormOptions: function(form, userOptions) {
+			 var options = form.data('jqv') ? form.data('jqv') : $.validationEngine.defaults;
+			 options = $.extend(true,{},options,userOptions);
+			 return options;
+		 },
 		 /**
 		 * Removes forbidden characters from class name
 		 * @param {String} className

--- a/js/languages/jquery.validationEngine-nl.js
+++ b/js/languages/jquery.validationEngine-nl.js
@@ -19,7 +19,7 @@
 	            "minSize": {
 	                "regex": "none",
 	                "alertText": "* Minimaal ",
-	                "alertText2": " karakters toegestaan"
+	                "alertText2": " karakters vereist"
 	            },
 	            "maxSize": {
 	                "regex": "none",
@@ -69,10 +69,8 @@
 	                "alertText": "* Ongeldig telefoonnummer"
 	            },
 	            "email": {
-	                // Shamelessly lifted from Scott Gonzalez via the Bassistance Validation plugin http://projects.scottsplayground.com/email_address_validation/
-                    // Replaced incredible long regex with shorter and working one! :)
-//	                "regex": /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i,
-	                "regex": /^[a-z0-9]+[a-z0-9._%+-]*@(?:[a-z0-9-]+\.)+[a-z]{2,6}$/i,
+                    // HTML5 compatible email regex ( http://www.whatwg.org/specs/web-apps/current-work/multipage/states-of-the-type-attribute.html#    e-mail-state-%28type=email%29 )
+                    "regex": /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
 	                "alertText": "* Ongeldig emailadres"
 	            },
 	            "integer": {


### PR DESCRIPTION
Problem: user options are ignored on action 'validate' when the target is a field.

My use case:
- several fields on a row should be validated when leaving a field on the row
- if the user missed an error preceding the current field, show a prompt (showPrompts: true / default)
- fields after the current field validate but this is only made visible by using setCustomValidity
- all this prevents clutter of error messages

Solution: use an options map during per field validation that is not saved but is based on the saved form options or otherwise on the defaults

Sorry for the .gitignore. I'm new to git(hub) and I do not see any controls to limit the set of commits.
