### PR TITLE
Update jquery.validationEngine-pt.js

### DIFF
--- a/js/languages/jquery.validationEngine-pt.js
+++ b/js/languages/jquery.validationEngine-pt.js
@@ -8,7 +8,7 @@
                     "regex": "none",
                     "alertText": "* Campo obrigatório",
                     "alertTextCheckboxMultiple": "* Selecione uma opção",
-					"alertTextCheckboxe": "* Selecione uma ou mais opções",
+		    "alertTextCheckboxe": "* Assinale a caixa de seleção",
                     "alertTextDateRange": "* Ambos os campos de datas são obrigatórios"
                 },
                 "requiredInFunction": { 


### PR DESCRIPTION
(PT) A mensagem anterior "Selecione uma ou mais opções" não faz sentido no caso de haver apenas uma checkbox e foi alterado para "Assinale a caixa de seleção". A mensagem original em inglês é "This checkbox is required".
---
(EN) The previous message "Selecione uma ou mais opções" (Please select one or more options) makes no sense if there is only one checkbox and was changed to "Tick the checkbox". The original message in English is "This checkbox is required".