### PR TITLE
Fix markdown syntax for documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Bundled with many locales, the error prompts can be translated into the language
 
 Documentation :
 ---
-###[Nicer documention](http://posabsolute.github.com/jQuery-Validation-Engine/)
-###[Release Notes](http://posabsolute.github.com/jQuery-Validation-Engine/releases.html)
+### [Nicer documention](http://posabsolute.github.com/jQuery-Validation-Engine/)
+### [Release Notes](http://posabsolute.github.com/jQuery-Validation-Engine/releases.html)
  
 
 Demo :


### PR DESCRIPTION
Hi, 
I fixed README.md which is not valid syntax for documentations.

Thanks